### PR TITLE
adding IformRequest

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,3 @@
+{
+  "presets": ["@babel/preset-react"]
+}

--- a/src/aws-exports.js
+++ b/src/aws-exports.js
@@ -5,7 +5,7 @@ const awsmobile = {
     "aws_cloud_logic_custom": [
         {
             "name": "iformapi",
-            "endpoint": "https://h10xrszoge.execute-api.us-east-1.amazonaws.com/dev",
+            "endpoint": "https://6ma8zovr1d.execute-api.us-east-1.amazonaws.com/dev/iform",
             "region": "us-east-1"
         }
     ]


### PR DESCRIPTION
Move authenticate endpoint to the server 
Add IformRequest 

**Usage**:
1. Use withAuthenticator:
` { withAuthenticator } from 'iformauth-react'`
`const config = { 
  servername: "loadapp"
}`
`export default withAuthenticator(App, config);`

2. Use APIs:
`import { IformRequest } from 'iformauth-react';`
 `IformRequest.get('profiles/10845/pages/290817343/records/10')`
				`.then(res=>{...})`
				`.catch(err=>{...});`
 `IformRequest.put('profiles/10845/pages/290817343/records/10', body)`
			`.then(res=>{...})`
			`.catch(err=>{...})`
 `IformRequest.post('profiles/10845/pages/290817343/records', body)`
			`.then(res=>{...})`
			`.catch(err=>{...})`
 `IformRequest.delete('profiles/10845/pages/290817343/records/10')`
			`.then(res=>{...})`
			`.catch(err=>{...})`